### PR TITLE
feat: proctoring webcam snapshots stored in AWS S3

### DIFF
--- a/S3_PROCTORING_SETUP.md
+++ b/S3_PROCTORING_SETUP.md
@@ -1,0 +1,164 @@
+# AWS S3 Setup for Proctoring Snapshots
+
+This guide walks you (step by step, no prior AWS experience assumed) through creating the
+S3 storage that holds the webcam snapshots captured during coding tests and AI interviews.
+Recruiters view these snapshots to confirm the same real person took the test and the
+interview.
+
+**What the app does with S3:** during a proctored session the candidate's browser sends a
+small webcam JPEG to *our* server every ~30 seconds. Our server uploads it to your **private**
+S3 bucket and stores only the object's key in MongoDB. When a recruiter opens the results, our
+server generates a short-lived **presigned URL** so the image loads in their browser. The images
+are never public.
+
+You only need to do this **once**. Total time: ~10 minutes.
+
+---
+
+## What you'll end up with (4 values)
+
+At the end you'll paste these into the server environment:
+
+| Variable | Example | What it is |
+|---|---|---|
+| `AWS_REGION` | `ap-south-1` | The region your bucket lives in |
+| `AWS_S3_BUCKET` | `zepul-proctoring-images` | Your bucket name |
+| `AWS_ACCESS_KEY_ID` | `AKIA...` | The app user's key id |
+| `AWS_SECRET_ACCESS_KEY` | `wJalr...` | The app user's secret (shown once) |
+
+---
+
+## Step 1 — Create an AWS account
+
+If you don't have one, go to <https://aws.amazon.com/> → **Create an AWS Account**. You'll need a
+credit card, but this feature costs pennies and the free tier covers 5 GB of S3 for the first 12
+months (see the cost note at the bottom).
+
+---
+
+## Step 2 — Create the S3 bucket (private)
+
+1. Sign in to the **AWS Management Console**.
+2. In the top search bar, type **S3** and open the **S3** service.
+3. Click **Create bucket**.
+4. **Bucket name:** enter a globally-unique name with **no dots**, e.g. `zepul-proctoring-images`.
+   (Dots can break the secure image URLs — use only lowercase letters, numbers, and hyphens.)
+5. **AWS Region:** pick one close to your users, e.g. **Asia Pacific (Mumbai) `ap-south-1`** or
+   **US East (N. Virginia) `us-east-1`**. **Write down the region code** — it's your `AWS_REGION`.
+6. **Block Public Access settings:** leave **"Block all public access" turned ON** (this is the
+   default). The images stay private; recruiters see them through temporary signed links.
+7. Leave everything else as default and click **Create bucket**.
+
+Your bucket name is your `AWS_S3_BUCKET`.
+
+---
+
+## Step 3 — Create a permissions policy
+
+This limits the app to only reading/writing *your* bucket — nothing else in your account.
+
+1. In the top search bar, open the **IAM** service.
+2. In the left menu, click **Policies** → **Create policy**.
+3. Click the **JSON** tab and paste the following, replacing **`YOUR_BUCKET_NAME`** with the bucket
+   name from Step 2 (keep the `/*` at the end):
+
+   ```json
+   {
+     "Version": "2012-10-17",
+     "Statement": [
+       {
+         "Sid": "ProctoringBucketReadWrite",
+         "Effect": "Allow",
+         "Action": ["s3:PutObject", "s3:GetObject"],
+         "Resource": "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+       }
+     ]
+   }
+   ```
+
+4. Click **Next**, give it a name like `zepul-proctoring-policy`, and click **Create policy**.
+
+---
+
+## Step 4 — Create the app user + access key
+
+1. Still in **IAM**, click **Users** → **Create user**.
+2. **User name:** e.g. `zepul-s3-uploader`.
+3. Do **NOT** check "Provide user access to the AWS Management Console" — the app only needs
+   programmatic access.
+4. Click **Next**. On the permissions page choose **Attach policies directly**, search for
+   `zepul-proctoring-policy` (from Step 3), check it, and click **Next** → **Create user**.
+5. Open the new user → **Security credentials** tab → **Create access key**.
+6. Choose **Application running outside AWS** → **Next** → **Create access key**.
+7. Copy both values now:
+   - **Access key ID** → this is `AWS_ACCESS_KEY_ID`
+   - **Secret access key** → this is `AWS_SECRET_ACCESS_KEY` (**shown only once** — copy it before
+     leaving the page; if you lose it, just create a new access key).
+
+---
+
+## Step 5 — Add the values to the server
+
+### Local development
+Open `server/.env` and fill in the four `AWS_*` values (placeholders are already there):
+
+```
+AWS_REGION=ap-south-1
+AWS_S3_BUCKET=zepul-proctoring-images
+AWS_ACCESS_KEY_ID=AKIA...your-key...
+AWS_SECRET_ACCESS_KEY=...your-secret...
+```
+
+Restart the server (`npm run dev` in `server/`).
+
+### Production (Render)
+The backend runs on Render. Open your backend service → **Environment** → add the same four
+variables → **Save**. Render will redeploy. (Never commit real keys to git — `server/.env` is
+already gitignored.)
+
+---
+
+## Step 6 — Verify it works
+
+1. As a recruiter, schedule a coding assessment for a test candidate and open the assessment link
+   (`/assessment/<id>`). The page will ask for camera permission — click **Allow**.
+2. Let it run ~1 minute, then check the **S3 console** → your bucket → you should see objects
+   appearing under `proctoring/assessments/...`.
+3. Do the same for an AI interview (`/meeting/<token>`); objects appear under
+   `proctoring/interviews/...`.
+4. Open the candidate's result in the recruiter dashboard — the **Proctoring Snapshots** gallery
+   shows the captured images.
+
+> Until these 4 values are set, the app still works normally — candidates just complete their
+> sessions and no images are stored (uploads are silently skipped). Camera permission is still
+> requested. Nothing breaks.
+
+---
+
+## Cost
+
+Webcam frames are tiny (tens of KB). A few thousand of them per month is a few **cents**. The AWS
+Free Tier includes 5 GB of S3 storage, 20,000 GET and 2,000 PUT requests per month for the first
+12 months, which comfortably covers normal usage. You can set a billing alert in **Billing →
+Budgets** if you want peace of mind.
+
+---
+
+## Security notes
+
+- The bucket is **private** ("Block all public access" ON). Images are never directly reachable by
+  URL — recruiters load them through short-lived signed links minted by our authenticated API.
+- The IAM user can only `PutObject`/`GetObject` on this one bucket — it cannot delete objects,
+  touch other buckets, or do anything else in your account.
+- If a key is ever leaked, delete it in **IAM → Users → Security credentials** and create a new one.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| No objects appear in S3 | Check the 4 env vars are set and the server was restarted. Check the server logs for `S3 is not configured` or an AWS error. |
+| Recruiter gallery is empty | The candidate may have taken the session before AWS was configured, or blocked their camera (you'll see a "Camera blocked by candidate" badge). |
+| `AccessDenied` in server logs | The IAM policy `Resource` must be `arn:aws:s3:::YOUR_BUCKET_NAME/*` and the policy must be attached to the user. |
+| `PermanentRedirect` / region errors | `AWS_REGION` must match the region you created the bucket in. |

--- a/client/src/Components/recruiter/dashboard/AIInterviewQuestions.jsx
+++ b/client/src/Components/recruiter/dashboard/AIInterviewQuestions.jsx
@@ -4,6 +4,7 @@ import { toast } from 'react-hot-toast';
 import { format, addDays } from 'date-fns';
 import ScheduleAssessmentModal from './ScheduleAssessmentModal';
 import AssessmentResultView from './AssessmentResultView';
+import ProctoringGallery from './ProctoringGallery';
 import ScheduleAvaloqAssessmentModal from './ScheduleAvaloqAssessmentModal';
 import AddAnswersPage from './AddAnswersPage';
 import { getAuthHeaders } from '../../../utils/authUtils';
@@ -590,6 +591,9 @@ const AIInterviewQuestions = ({ jobDetails, resumeData, onBack, onResumeUpdate }
                 <p className="text-sm mt-2">Link: <span className="font-mono bg-gray-100 px-2 py-1 rounded">{`${window.location.origin}/assessment/${resumeData.oa.assessmentId}`}</span></p>
               </div>
             )}
+            {resumeData.oa.assessmentId && (
+              <ProctoringGallery endpoint={`/api/assessment/${resumeData.oa.assessmentId}/screenshots`} />
+            )}
           </div>
         )}
 
@@ -614,6 +618,9 @@ const AIInterviewQuestions = ({ jobDetails, resumeData, onBack, onResumeUpdate }
                 <p>Avaloq Banking Assessment has been scheduled and sent to the candidate.</p>
                 <p className="text-sm mt-2">Link: <span className="font-mono bg-gray-100 px-2 py-1 rounded">{`${window.location.origin}/assessment/${resumeData.avaloqOa.assessmentId}`}</span></p>
               </div>
+            )}
+            {resumeData.avaloqOa.assessmentId && (
+              <ProctoringGallery endpoint={`/api/assessment/${resumeData.avaloqOa.assessmentId}/screenshots`} />
             )}
           </div>
         )}

--- a/client/src/Components/recruiter/dashboard/InterviewResultsDashboard.jsx
+++ b/client/src/Components/recruiter/dashboard/InterviewResultsDashboard.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Calendar, Clock, User, Briefcase, FileText, Play, Download, TrendingUp, Award, MessageSquare, AlertCircle, CheckCircle, XCircle, Target, BarChart3, Zap, Users, Brain, Mic, Star, HelpCircle, Mail, Phone, MapPin, ThumbsUp, Lightbulb, BookOpen } from "lucide-react";
 import { toast } from "react-hot-toast";
 import { getApiUrl } from "../../../config/config";
+import ProctoringGallery from "./ProctoringGallery";
 
 const CircularProgress = ({ percentage, size = 160, strokeWidth = 14 }) => {
   const radius = (size - strokeWidth) / 2;
@@ -374,6 +375,12 @@ const InterviewResultsDashboard = ({ meetingId, onBack }) => {
                   </div>
                 </div>
               )}
+
+              {/* Proctoring snapshots captured during the interview (self-hides when none). */}
+              <ProctoringGallery
+                endpoint={`/api/meetings/${meetingId}/screenshots`}
+                title="Identity Verification — Webcam Snapshots"
+              />
 
               {/* Meeting Details */}
               <div className="p-6 border rounded-xl bg-gray-50">

--- a/client/src/Components/recruiter/dashboard/ProctoringGallery.jsx
+++ b/client/src/Components/recruiter/dashboard/ProctoringGallery.jsx
@@ -1,0 +1,141 @@
+import React, { useEffect, useState } from "react";
+import { Camera, CameraOff, X } from "lucide-react";
+import { getApiUrl } from "../../../config/config";
+import { getAuthHeaders } from "../../../utils/authUtils";
+
+/**
+ * Displays the proctoring webcam snapshots captured during a coding test or interview.
+ * Fetches presigned image URLs from `endpoint` (a recruiter-authenticated API path such as
+ * `/api/assessment/:id/screenshots` or `/api/meetings/:id/screenshots`).
+ *
+ * Self-hiding: renders nothing when there are no snapshots and no consent record, so it's
+ * safe to drop into a result view regardless of whether the candidate has taken the session.
+ */
+const ProctoringGallery = ({ endpoint, title = "Proctoring Snapshots" }) => {
+  const [loading, setLoading] = useState(true);
+  const [screenshots, setScreenshots] = useState([]);
+  const [consent, setConsent] = useState(null);
+  const [lightbox, setLightbox] = useState(null); // { url, capturedAt } | null
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      if (!endpoint) return;
+      setLoading(true);
+      try {
+        const res = await fetch(getApiUrl(endpoint), {
+          headers: getAuthHeaders(),
+          credentials: "include",
+        });
+        if (!res.ok) throw new Error(`Failed (${res.status})`);
+        const data = await res.json();
+        if (cancelled) return;
+        setScreenshots(Array.isArray(data.screenshots) ? data.screenshots : []);
+        setConsent(data.consent || null);
+      } catch (err) {
+        if (!cancelled) {
+          console.error("Failed to load proctoring snapshots:", err?.message);
+          setScreenshots([]);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, [endpoint]);
+
+  const fmt = (d) => {
+    try {
+      return new Date(d).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+    } catch {
+      return "";
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="mt-4 text-sm text-gray-400 flex items-center gap-2">
+        <Camera size={16} /> Loading proctoring snapshots…
+      </div>
+    );
+  }
+
+  // Nothing captured and no consent recorded → nothing meaningful to show.
+  if (!screenshots.length && consent !== "denied") return null;
+
+  return (
+    <div className="mt-6 border-t border-gray-200 pt-5">
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-base font-bold text-gray-800 flex items-center gap-2">
+          <Camera size={18} className="text-blue-600" /> {title}
+          {screenshots.length > 0 && (
+            <span className="text-xs font-normal text-gray-500">({screenshots.length})</span>
+          )}
+        </h4>
+        {consent === "denied" && (
+          <span className="inline-flex items-center gap-1 text-xs font-semibold text-red-700 bg-red-50 px-2 py-1 rounded-full">
+            <CameraOff size={14} /> Camera blocked by candidate
+          </span>
+        )}
+      </div>
+
+      {screenshots.length === 0 ? (
+        <p className="text-sm text-gray-500">
+          No snapshots were captured — the candidate did not grant camera access.
+        </p>
+      ) : (
+        <>
+          <p className="text-xs text-gray-500 mb-3">
+            Captured periodically during the session for identity verification. Click any image to enlarge.
+          </p>
+          <div className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 gap-2">
+            {screenshots.map((s, idx) => (
+              <button
+                key={idx}
+                type="button"
+                onClick={() => setLightbox(s)}
+                className="group relative rounded-lg overflow-hidden border border-gray-200 hover:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                title={fmt(s.capturedAt)}
+              >
+                <img
+                  src={s.url}
+                  alt={`Snapshot ${idx + 1}`}
+                  loading="lazy"
+                  className="w-full h-20 object-cover bg-gray-100"
+                />
+                <span className="absolute bottom-0 inset-x-0 bg-black/50 text-white text-[10px] px-1 py-0.5 opacity-0 group-hover:opacity-100 transition-opacity">
+                  {fmt(s.capturedAt)}
+                </span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+
+      {lightbox && (
+        <div
+          className="fixed inset-0 z-50 bg-black/80 flex items-center justify-center p-4"
+          onClick={() => setLightbox(null)}
+        >
+          <div className="relative max-w-3xl w-full" onClick={(e) => e.stopPropagation()}>
+            <button
+              type="button"
+              onClick={() => setLightbox(null)}
+              className="absolute -top-3 -right-3 bg-white rounded-full p-1 shadow-lg text-gray-700 hover:text-gray-900"
+              aria-label="Close"
+            >
+              <X size={20} />
+            </button>
+            <img src={lightbox.url} alt="Snapshot" className="w-full rounded-lg" />
+            <div className="text-center text-white text-sm mt-2">Captured at {fmt(lightbox.capturedAt)}</div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ProctoringGallery;

--- a/client/src/Pages/CandidateAssessmentPage.jsx
+++ b/client/src/Pages/CandidateAssessmentPage.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import Editor from '@monaco-editor/react';
-import { Loader2, Play, Send, CheckCircle, AlertCircle, Clock, Check, X, ChevronLeft, ChevronRight, Award } from 'lucide-react';
+import { Loader2, Play, Send, CheckCircle, AlertCircle, Clock, Check, X, ChevronLeft, ChevronRight, Award, Camera } from 'lucide-react';
 import toast from 'react-hot-toast';
 import initSqlJs from 'sql.js';
 import { config } from '../config/config';
+import { requestCamera, stopStream, captureAndUpload, CAPTURE_INTERVAL_MS } from '../utils/proctoring';
 
 const CandidateAssessmentPage = () => {
     const { assessmentId } = useParams();
@@ -26,13 +27,84 @@ const CandidateAssessmentPage = () => {
     const [assessmentType, setAssessmentType] = useState('standard'); // 'standard' or 'avaloq'
     const sqlDbRef = useRef(null);
 
+    // Proctoring: this assessment is camera-gated. The test stays blocked (and the timer
+    // paused) until the candidate grants webcam access; frames are then captured periodically.
+    const [cameraReady, setCameraReady] = useState(false);
+    const [cameraDenied, setCameraDenied] = useState(false);
+    const videoRef = useRef(null);
+    const canvasRef = useRef(null);
+    const mediaStreamRef = useRef(null);
+    const captureIntervalRef = useRef(null);
+
     useEffect(() => {
         fetchAssessment();
     }, [assessmentId]);
 
-    // Timer countdown
+    // Acquire the webcam on mount. Does not touch videoRef here (it may not be mounted yet
+    // behind the loading state); a separate effect attaches the stream once both are ready.
     useEffect(() => {
-        if (!assessment || assessment.completed) return;
+        let cancelled = false;
+        const enableCamera = async () => {
+            try {
+                const stream = await requestCamera();
+                if (cancelled) { stopStream(stream); return; }
+                mediaStreamRef.current = stream;
+                setCameraReady(true);
+                setCameraDenied(false);
+            } catch (err) {
+                console.error('Camera access denied:', err);
+                setCameraDenied(true);
+                // Record the denial best-effort so the recruiter sees why no frames exist.
+                try {
+                    const form = new FormData();
+                    form.append('consent', 'denied');
+                    fetch(`${config.backendUrl}/api/assessment/${assessmentId}/screenshot`, {
+                        method: 'POST',
+                        body: form,
+                    }).catch(() => {});
+                } catch { /* ignore */ }
+            }
+        };
+        enableCamera();
+        return () => {
+            cancelled = true;
+            stopStream(mediaStreamRef.current);
+        };
+    }, [assessmentId]);
+
+    // Attach the live stream to the <video> once both the stream and the element exist.
+    useEffect(() => {
+        const el = videoRef.current;
+        if (!el || !mediaStreamRef.current) return;
+        if (el.srcObject !== mediaStreamRef.current) {
+            el.srcObject = mediaStreamRef.current;
+        }
+        el.play?.().catch(() => {});
+    }, [cameraReady, loading, assessment]);
+
+    // Proctoring capture loop: runs only while the camera is ready and the test is in progress.
+    // When the assessment completes (manual/auto submit) or the component unmounts, the cleanup
+    // clears the interval — so there is no separate teardown to maintain.
+    useEffect(() => {
+        if (!cameraReady || !assessment || assessment.completed) return;
+        const url = `${config.backendUrl}/api/assessment/${assessmentId}/screenshot`;
+        const tick = () => captureAndUpload(videoRef.current, canvasRef.current, url, 'granted');
+        const warmup = setTimeout(tick, 2500); // let the <video> start painting frames first
+        captureIntervalRef.current = setInterval(tick, CAPTURE_INTERVAL_MS);
+        return () => {
+            clearTimeout(warmup);
+            if (captureIntervalRef.current) {
+                clearInterval(captureIntervalRef.current);
+                captureIntervalRef.current = null;
+            }
+        };
+        // Depend on the assessment object (not just .completed) so capture starts once the
+        // assessment loads even if the camera was granted first, and stops when it completes.
+    }, [cameraReady, assessment, assessmentId]);
+
+    // Timer countdown — gated on cameraReady so time doesn't burn during the permission prompt.
+    useEffect(() => {
+        if (!assessment || assessment.completed || !cameraReady) return;
 
         const timer = setInterval(() => {
             setTimeRemaining(prev => {
@@ -46,7 +118,7 @@ const CandidateAssessmentPage = () => {
         }, 1000);
 
         return () => clearInterval(timer);
-    }, [assessment]);
+    }, [assessment, cameraReady]);
 
     const formatTime = (seconds) => {
         const mins = Math.floor(seconds / 60);
@@ -737,6 +809,46 @@ function ${functionName}(...args) {
 
     return (
         <div className="flex flex-col h-screen bg-gray-100 overflow-hidden">
+            {/* Offscreen canvas used to grab proctoring frames from the camera preview. */}
+            <canvas ref={canvasRef} style={{ display: 'none' }} />
+
+            {/* Proctoring gate: blocks the whole test until the candidate grants camera access. */}
+            {!cameraReady && (
+                <div className="fixed inset-0 z-50 bg-gray-900/80 backdrop-blur-sm flex items-center justify-center p-4">
+                    <div className="bg-white rounded-2xl shadow-xl max-w-md w-full text-center p-8">
+                        <div className="flex items-center justify-center w-16 h-16 rounded-full bg-blue-100 mx-auto mb-5">
+                            <Camera className="text-blue-600" size={32} />
+                        </div>
+                        <h2 className="text-2xl font-bold text-gray-900 mb-2">Camera access required</h2>
+                        {cameraDenied ? (
+                            <>
+                                <p className="text-gray-600 mb-6">
+                                    This assessment is <strong>proctored</strong>. Camera access was blocked.
+                                    Please allow the camera in your browser, then click Retry.
+                                </p>
+                                <button
+                                    onClick={() => window.location.reload()}
+                                    className="bg-blue-600 text-white px-5 py-2 rounded-lg font-medium hover:bg-blue-700"
+                                >
+                                    Retry
+                                </button>
+                            </>
+                        ) : (
+                            <>
+                                <p className="text-gray-600 mb-6">
+                                    This assessment is <strong>proctored</strong> — your webcam is captured
+                                    periodically for identity verification. Please click <strong>Allow</strong>
+                                    on the browser prompt to begin. Your timer will not start until then.
+                                </p>
+                                <div className="flex items-center justify-center gap-2 text-gray-500">
+                                    <Loader2 className="animate-spin" size={18} /> Waiting for camera…
+                                </div>
+                            </>
+                        )}
+                    </div>
+                </div>
+            )}
+
             {/* Header */}
             <header className="bg-white border-b border-gray-200 px-6 py-3 flex justify-between items-center shadow-sm z-10">
                 <div className="flex items-center gap-3">
@@ -746,6 +858,20 @@ function ${functionName}(...args) {
                         <div className="flex items-center gap-2 text-xs text-gray-500">
                             <span>Candidate: {assessment.candidateName}</span>
                         </div>
+                    </div>
+                    {/* Live camera preview — a visible reminder that the session is proctored. */}
+                    <div className="relative ml-2">
+                        <video
+                            ref={videoRef}
+                            autoPlay
+                            playsInline
+                            muted
+                            className="w-20 h-14 rounded-md object-cover bg-black border border-gray-300"
+                        />
+                        <span className="absolute -top-1 -right-1 flex h-3 w-3">
+                            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75"></span>
+                            <span className="relative inline-flex rounded-full h-3 w-3 bg-red-500"></span>
+                        </span>
                     </div>
                 </div>
 

--- a/client/src/Pages/Meeting.jsx
+++ b/client/src/Pages/Meeting.jsx
@@ -3,6 +3,7 @@ import Vapi from "@vapi-ai/web";
 import { useParams } from "react-router-dom";
 import { Clock } from "lucide-react";
 import { getApiUrl } from "../config/config";
+import { captureAndUpload, CAPTURE_INTERVAL_MS } from "../utils/proctoring";
 
 const Meeting = () => {
   const { token } = useParams();
@@ -17,12 +18,32 @@ const Meeting = () => {
   const [timeWarning, setTimeWarning] = useState(null); // '10min', '5min', '2min', '1min', 'grace'
   const [gracePeriodActive, setGracePeriodActive] = useState(false);
   const [cameraStream, setCameraStream] = useState(null);
+  const [cameraDenied, setCameraDenied] = useState(false); // proctoring: camera required to start
   const videoRef = useRef(null);
+  const canvasRef = useRef(null); // offscreen canvas for capturing proctoring frames
+  const captureIntervalRef = useRef(null); // proctoring capture loop
   const mediaStreamRef = useRef(null);
   const vapiRef = useRef(null);
   const timerIntervalRef = useRef(null);
   const gracePeriodRef = useRef(null);
   const warningsShownRef = useRef(new Set()); // Track which warnings have been shown
+
+  // Proctoring: capture one webcam frame now and every CAPTURE_INTERVAL_MS.
+  // Reuses the already-live videoRef stream (no second getUserMedia). Best-effort uploads.
+  const startProctoring = () => {
+    if (captureIntervalRef.current) return; // already running
+    const url = getApiUrl(`/api/meetings/${token}/screenshot`);
+    const tick = () => captureAndUpload(videoRef.current, canvasRef.current, url, "granted");
+    tick();
+    captureIntervalRef.current = setInterval(tick, CAPTURE_INTERVAL_MS);
+  };
+
+  const stopProctoring = () => {
+    if (captureIntervalRef.current) {
+      clearInterval(captureIntervalRef.current);
+      captureIntervalRef.current = null;
+    }
+  };
 
   // Load meeting metadata
   useEffect(() => {
@@ -68,8 +89,10 @@ const Meeting = () => {
         }
         mediaStreamRef.current = stream;
         setCameraStream(stream);
+        setCameraDenied(false);
       } catch (err) {
         console.error("Unable to access camera:", err);
+        setCameraDenied(true); // proctoring: block the interview until camera is granted
       }
     };
 
@@ -77,6 +100,7 @@ const Meeting = () => {
 
     return () => {
       cancelled = true;
+      stopProctoring();
       if (mediaStreamRef.current) {
         mediaStreamRef.current.getTracks().forEach((t) => t.stop());
       }
@@ -175,6 +199,7 @@ const Meeting = () => {
                 console.log("Vapi stop called during auto-end (may show expected error):", err);
               }
             }
+            stopProctoring();
             if (mediaStreamRef.current) {
               mediaStreamRef.current.getTracks().forEach((t) => t.stop());
             }
@@ -249,6 +274,8 @@ const Meeting = () => {
         // Start timer
         const durationMs = (meeting?.durationMinutes || 40) * 60 * 1000;
         setTimeRemaining(durationMs);
+        // Proctoring: the meeting is now 'active' server-side, so frames will be accepted.
+        startProctoring();
       });
 
       vapi.on("call-end", () => {
@@ -259,6 +286,8 @@ const Meeting = () => {
         setGracePeriodActive(false);
         setTimeWarning(null);
         warningsShownRef.current.clear();
+        // Stop proctoring capture
+        stopProctoring();
         // Stop camera
         if (mediaStreamRef.current) {
           mediaStreamRef.current.getTracks().forEach((t) => t.stop());
@@ -306,6 +335,9 @@ const Meeting = () => {
     try {
       // Stop the Vapi call
       vapiRef.current.stop();
+
+      // Stop proctoring capture
+      stopProctoring();
 
       // Stop camera
       if (mediaStreamRef.current) {
@@ -572,14 +604,42 @@ const Meeting = () => {
                     )}
                   </div>
                 )}
+                {!isConnected && (
+                  <div className="alert alert-secondary py-2 px-3 mb-3 small d-flex align-items-center gap-2">
+                    <span aria-hidden="true">📷</span>
+                    <span>
+                      This interview is <strong>proctored</strong> — your webcam is
+                      captured periodically for identity verification. Camera access
+                      is required to start.
+                    </span>
+                  </div>
+                )}
+                {!isConnected && cameraDenied && (
+                  <div className="alert alert-warning py-2 px-3 mb-3 small">
+                    <strong>Camera blocked.</strong> Please allow camera access in your
+                    browser, then reload this page to begin.
+                    <button
+                      type="button"
+                      className="btn btn-sm btn-outline-dark ms-2"
+                      onClick={() => window.location.reload()}
+                    >
+                      Reload
+                    </button>
+                  </div>
+                )}
                 <div className="mt-auto d-flex gap-2">
                   {!isConnected ? (
                     <button
                       className="btn btn-primary flex-grow-1"
                       onClick={startInterview}
-                      disabled={starting}
+                      disabled={starting || !cameraStream}
+                      title={!cameraStream ? "Waiting for camera access…" : undefined}
                     >
-                      {starting ? "Starting..." : "Start Interview"}
+                      {starting
+                        ? "Starting..."
+                        : !cameraStream
+                          ? "Waiting for camera…"
+                          : "Start Interview"}
                     </button>
                   ) : (
                     <button
@@ -590,6 +650,8 @@ const Meeting = () => {
                     </button>
                   )}
                 </div>
+                {/* Offscreen canvas used to grab proctoring frames from the video. */}
+                <canvas ref={canvasRef} style={{ display: "none" }} />
               </div>
             </div>
           </div>

--- a/client/src/utils/proctoring.js
+++ b/client/src/utils/proctoring.js
@@ -1,0 +1,66 @@
+// Shared helpers for proctoring: capture periodic webcam frames and upload them.
+// Used by both the coding test (CandidateAssessmentPage) and the AI interview (Meeting).
+//
+// Design notes:
+// - Frames are small JPEGs (downscaled to ~640px, quality 0.7) → tens of KB each.
+// - Uploads are multipart/form-data (field name "file") and are BEST-EFFORT: a failed
+//   upload (e.g. AWS not yet configured, transient network) is swallowed so it can never
+//   break or block the candidate's session.
+
+// How often to capture a frame during a proctored session (ms).
+export const CAPTURE_INTERVAL_MS = 30 * 1000;
+
+// Request the webcam. Resolves to a MediaStream, or throws if denied/unavailable.
+export const requestCamera = () =>
+  navigator.mediaDevices.getUserMedia({
+    video: { width: { ideal: 640 }, height: { ideal: 480 } },
+    audio: false,
+  });
+
+// Stop all tracks on a stream (idempotent, null-safe).
+export const stopStream = (stream) => {
+  try {
+    stream?.getTracks?.().forEach((t) => t.stop());
+  } catch {
+    /* ignore */
+  }
+};
+
+// Draw the current <video> frame to an offscreen <canvas> and return a JPEG Blob
+// (or null if the video isn't ready). Never throws.
+export const captureFrameBlob = (videoEl, canvasEl, { maxWidth = 640, quality = 0.7 } = {}) =>
+  new Promise((resolve) => {
+    try {
+      if (!videoEl || !canvasEl || !videoEl.videoWidth) return resolve(null);
+      const scale = Math.min(1, maxWidth / videoEl.videoWidth);
+      const w = Math.max(1, Math.round(videoEl.videoWidth * scale));
+      const h = Math.max(1, Math.round(videoEl.videoHeight * scale));
+      canvasEl.width = w;
+      canvasEl.height = h;
+      const ctx = canvasEl.getContext("2d");
+      ctx.drawImage(videoEl, 0, 0, w, h);
+      canvasEl.toBlob((blob) => resolve(blob), "image/jpeg", quality);
+    } catch {
+      resolve(null);
+    }
+  });
+
+// POST one frame to an upload endpoint. Best-effort — resolves even on failure.
+export const uploadFrame = async (url, blob, consent) => {
+  if (!blob) return;
+  try {
+    const form = new FormData();
+    form.append("file", blob, "frame.jpg");
+    if (consent) form.append("consent", consent);
+    await fetch(url, { method: "POST", body: form });
+  } catch (e) {
+    // Swallow: proctoring upload must never break the candidate's session.
+    console.debug("[proctoring] frame upload failed:", e?.message);
+  }
+};
+
+// Convenience: capture the current frame and upload it in one call.
+export const captureAndUpload = async (videoEl, canvasEl, url, consent) => {
+  const blob = await captureFrameBlob(videoEl, canvasEl);
+  await uploadFrame(url, blob, consent);
+};

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -10,6 +10,8 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
+        "@aws-sdk/client-s3": "^3.1088.0",
+        "@aws-sdk/s3-request-presigner": "^3.1088.0",
         "axios": "^1.11.0",
         "bcryptjs": "^3.0.2",
         "cloudinary": "^2.6.1",
@@ -35,6 +37,331 @@
         "pdfjs-dist": "^3.11.174",
         "twilio": "^6.0.2",
         "xlsx": "^0.18.5"
+      }
+    },
+    "node_modules/@aws-sdk/checksums": {
+      "version": "3.1000.18",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.18.tgz",
+      "integrity": "sha512-IImkbEyXdV6/uaF5r6Wkk+8718mQw1ll83j0a4a30R3JM/rHVFdWAiT4jtJpFjJiIwM/oJ6SxIxr0z2TaQUGqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1088.0.tgz",
+      "integrity": "sha512-9ryKKxnjtJRKLDI24P+2gQZki7k28BeV6gz1AySvFDWayhjAZuh4QZjCyx55tqR8Oz0IJxWutgJRO43dDOcXoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/checksums": "^3.1000.18",
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-node": "^3.972.69",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.64",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.975.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.975.3.tgz",
+      "integrity": "sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@aws-sdk/xml-builder": "^3.972.36",
+        "@aws/lambda-invoke-store": "^0.3.0",
+        "@smithy/core": "^3.29.4",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.59.tgz",
+      "integrity": "sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.61",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.61.tgz",
+      "integrity": "sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.3.tgz",
+      "integrity": "sha512-WpuqYX4gGkx++fCTSWE8+41JzkZVcrI50SH48Ml4CsG1pyuHKyMmpw/FixBHDrmjoQ553PmeCLa/fZIcst+WyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-login": "^3.972.65",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.65.tgz",
+      "integrity": "sha512-xr9rgjYEdmC2Tpg2lwt9o+nOEaK9Qpd+dBjzrVCuWWyQfvhO91Ezu0Hh9ts2VUxOZxmS/k5T9msa34e4R1bnrQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.69.tgz",
+      "integrity": "sha512-wbJGGesd0Tl18bmUcbj1xJ+e7CpuRJ6PIpMywLFuUttGy615lua87cJ0EA8pFpY/QgPuUXbnupWBtSPJ9tyZhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.59",
+        "@aws-sdk/credential-provider-http": "^3.972.61",
+        "@aws-sdk/credential-provider-ini": "^3.973.3",
+        "@aws-sdk/credential-provider-process": "^3.972.59",
+        "@aws-sdk/credential-provider-sso": "^3.973.3",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.65",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/credential-provider-imds": "^4.4.9",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.59.tgz",
+      "integrity": "sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.973.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.3.tgz",
+      "integrity": "sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/token-providers": "3.1088.0",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.65",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.65.tgz",
+      "integrity": "sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.972.64",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.64.tgz",
+      "integrity": "sha512-RBi43anhDBUv+HCfxCOXwGOE7GmT4n7ChV04Mwr22RhXTNcamW/iWnJlOotDPCZSrJ4dEvhZSiWWQMwLX+ZhFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.33.tgz",
+      "integrity": "sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/fetch-http-handler": "^5.6.6",
+        "@smithy/node-http-handler": "^4.9.6",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1088.0.tgz",
+      "integrity": "sha512-NEv9O5q+IrsDNKPmNhTlZ3hjtomgfL1OEJRCmDSF06dbmZ6IUJfrLQTLO7LWbM4sxvYui1LRAFCdO2TM3Hdq4A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.41",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.41.tgz",
+      "integrity": "sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/signature-v4": "^5.6.5",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.1088.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1088.0.tgz",
+      "integrity": "sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.975.3",
+        "@aws-sdk/nested-clients": "^3.997.33",
+        "@aws-sdk/types": "^3.974.2",
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.974.2",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.2.tgz",
+      "integrity": "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.36.tgz",
+      "integrity": "sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+      "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -138,6 +465,87 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.29.4",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.29.4.tgz",
+      "integrity": "sha512-G1GRglAabzEhqghJMBAd54FkRS7SAFGHEwbhcI9r+O+LIMuFsLyXkLZkCoFSgAglRu8s/URVXJB0hglq3ZipIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.9.tgz",
+      "integrity": "sha512-2nfV4qRKiYeXU4zD2vvSCfg5dfp/BuhrM73vt7q9gzBhxs4rbPxXY21wo+kyI3bRmXcEGRnCLTaW8O437jzHIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.6.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.6.tgz",
+      "integrity": "sha512-NHLgAlORUFZjn5ZfhYuyyKMlXA1WLYOdGxEhyNxrPpbJzoacGbl0chn1lN2KiZ8mpNVk0tV5607CSYlYs/OFgw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.9.6",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.6.tgz",
+      "integrity": "sha512-odd+HYx3OLcXRSEz0ZeF3JQdSYdK8QnRgA2N87cPW7coWIbKfRk7a9VQjfeWQLqnzrDLk23KMEn46p8N7M/JFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.5.tgz",
+      "integrity": "sha512-MO5VEhwVl0BN7xVoVeNrZfiUFoQtqxUbgl6/RwOTlMMxCSjblG8twSrVTwz3J4w9WZxd2rBfBAUXjH77agspBg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.29.4",
+        "@smithy/types": "^4.16.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.16.1.tgz",
+      "integrity": "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -465,6 +873,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/bowser": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -3594,6 +4008,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/twilio": {
       "version": "6.0.2",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,8 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.1088.0",
+    "@aws-sdk/s3-request-presigner": "^3.1088.0",
     "axios": "^1.11.0",
     "bcryptjs": "^3.0.2",
     "cloudinary": "^2.6.1",

--- a/server/src/controllers/assessment.controller.js
+++ b/server/src/controllers/assessment.controller.js
@@ -7,6 +7,7 @@ import nodemailer from "nodemailer";
 import { executeJava, executeCpp, executePython } from "../services/codeExecution.service.js";
 import { sendMeetingInviteEmail } from "../services/email.service.js";
 import { sendWhatsAppMessage } from "../utils/whatsapp.js";
+import { isS3Configured, uploadBufferToS3, getSignedImageUrl } from "../utils/s3.js";
 
 const FRONTEND_URL = process.env.FRONTEND_URL || process.env.FRONT_END_URL || "http://localhost:5173";
 const INTERVIEW_LEAD_TIME_MS = 5 * 60 * 1000; // 5 minutes — gives the candidate a moment to read the invite
@@ -926,5 +927,118 @@ const evaluateSubmission = async (resumeId, submissions, questions, assessmentFi
   } catch (error) {
     console.error("Error evaluating submission:", error);
     // Fallback logic...
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Proctoring: webcam snapshots captured during the coding test.
+// Images live in a private S3 bucket; we persist only the object key and mint
+// short-lived presigned URLs when a recruiter views the results.
+// ---------------------------------------------------------------------------
+
+// Keep at most this many frames per session (atomic $slice cap). A 90-min Avaloq
+// test at one frame / 30s produces ~180 frames, so this preserves full coverage
+// for normal sessions while bounding document growth against abuse.
+const MAX_ASSESSMENT_SCREENSHOTS = 200;
+
+// Resolve the resume and which sub-field ('oa' | 'avaloqOa') an assessmentId belongs to.
+const findResumeByAssessmentId = async (assessmentId) => {
+  let resume = await Resume.findOne({ "oa.assessmentId": assessmentId });
+  if (resume) return { resume, field: "oa" };
+  resume = await Resume.findOne({ "avaloqOa.assessmentId": assessmentId });
+  if (resume) return { resume, field: "avaloqOa" };
+  return { resume: null, field: null };
+};
+
+// @desc  Store one webcam frame for a coding-test session
+// @route POST /api/assessment/:assessmentId/screenshot  (PUBLIC — gated by assessmentId)
+export const uploadAssessmentScreenshot = async (req, res) => {
+  try {
+    const { assessmentId } = req.params;
+
+    const { resume, field } = await findResumeByAssessmentId(assessmentId);
+    if (!resume) return res.status(404).json({ message: "Assessment not found" });
+
+    // Record consent once (client sends it with every frame; harmless to re-set).
+    if (req.body?.consent === "granted" || req.body?.consent === "denied") {
+      await Resume.updateOne(
+        { [`${field}.assessmentId`]: assessmentId },
+        { $set: { [`${field}.proctoring.consent`]: req.body.consent } }
+      );
+    }
+
+    // Storage not configured yet: accept-and-ignore so the candidate is never blocked.
+    if (!isS3Configured()) {
+      return res.status(200).json({ stored: false, reason: "storage-not-configured" });
+    }
+    if (!req.file) return res.status(400).json({ message: "No image uploaded" });
+
+    const status = resume[field]?.status;
+    if (status === "completed" || status === "evaluated") {
+      return res.status(409).json({ message: "Assessment already completed" });
+    }
+
+    const capturedAt = new Date();
+    const rand = crypto.randomBytes(6).toString("hex");
+    // Key is fully server-derived — never trust a client-supplied path.
+    const key = `proctoring/assessments/${resume._id}/${assessmentId}/${capturedAt.getTime()}-${rand}.jpg`;
+
+    await uploadBufferToS3(req.file.buffer, key, req.file.mimetype);
+
+    await Resume.updateOne(
+      { [`${field}.assessmentId`]: assessmentId },
+      {
+        $push: {
+          [`${field}.screenshots`]: {
+            $each: [{ key, capturedAt }],
+            $slice: -MAX_ASSESSMENT_SCREENSHOTS,
+          },
+        },
+      }
+    );
+
+    return res.status(201).json({ stored: true, capturedAt });
+  } catch (error) {
+    console.error("Error uploading assessment screenshot:", error);
+    return res.status(500).json({ message: "Failed to store screenshot" });
+  }
+};
+
+// @desc  Fetch presigned URLs for a session's proctoring snapshots
+// @route GET /api/assessment/:assessmentId/screenshots  (recruiter/manager/admin)
+export const getAssessmentScreenshots = async (req, res) => {
+  try {
+    const { assessmentId } = req.params;
+    const { resume, field } = await findResumeByAssessmentId(assessmentId);
+    if (!resume) return res.status(404).json({ message: "Assessment not found" });
+
+    // Ownership: a recruiter may only read their own candidates' frames; managers/admins bypass.
+    if (req.role === "recruiter" && String(resume.recruiterId) !== String(req.id)) {
+      return res.status(403).json({ message: "Not authorized to view these screenshots" });
+    }
+
+    const shots = resume[field]?.screenshots || [];
+    const screenshots = (
+      await Promise.all(
+        shots.map(async (s) => {
+          try {
+            const url = await getSignedImageUrl(s.key);
+            return url ? { url, capturedAt: s.capturedAt } : null;
+          } catch (e) {
+            console.error("Presign failed for", s.key, e?.message);
+            return null;
+          }
+        })
+      )
+    ).filter(Boolean);
+
+    return res.status(200).json({
+      consent: resume[field]?.proctoring?.consent || null,
+      count: screenshots.length,
+      screenshots,
+    });
+  } catch (error) {
+    console.error("Error fetching assessment screenshots:", error);
+    return res.status(500).json({ message: "Failed to fetch screenshots" });
   }
 };

--- a/server/src/controllers/meeting.controller.js
+++ b/server/src/controllers/meeting.controller.js
@@ -11,6 +11,7 @@ import {
   sendMeetingCancelEmail,
   sendMeetingRescheduleEmail,
 } from "../services/email.service.js";
+import { isS3Configured, uploadBufferToS3, getSignedImageUrl } from "../utils/s3.js";
 
 const openai = process.env.OPENAI_API ? new OpenAI({ apiKey: process.env.OPENAI_API }) : null;
 const INTERVIEW_SUMMARY_MODEL = "gpt-4o-mini";
@@ -1060,3 +1061,98 @@ export const handleVapiWebhook = async (req, res) => {
   }
 };
 
+
+// ---------------------------------------------------------------------------
+// Proctoring: webcam snapshots captured during the AI video interview.
+// Images live in a private S3 bucket; only the object key is stored, and
+// presigned URLs are minted when the recruiter opens the results dashboard.
+// ---------------------------------------------------------------------------
+
+const MAX_MEETING_SCREENSHOTS = 200;
+
+// @desc  Store one webcam frame for an interview session
+// @route POST /api/meetings/:token/screenshot  (PUBLIC — gated by the meeting token)
+export const uploadMeetingScreenshot = async (req, res) => {
+  try {
+    const { token } = req.params;
+    const meeting = await Meeting.findOne({ token });
+    if (!meeting) return res.status(404).json({ message: "Meeting not found" });
+
+    // Record consent once (client sends it with every frame).
+    if (req.body?.consent === "granted" || req.body?.consent === "denied") {
+      await Meeting.updateOne({ token }, { $set: { proctoringConsent: req.body.consent } });
+    }
+
+    // Storage not configured yet: accept-and-ignore so the interview is never blocked.
+    if (!isS3Configured()) {
+      return res.status(200).json({ stored: false, reason: "storage-not-configured" });
+    }
+    if (!req.file) return res.status(400).json({ message: "No image uploaded" });
+
+    // Only accept frames while the interview is live.
+    if (meeting.status !== "active") {
+      return res.status(409).json({ message: "Meeting is not active" });
+    }
+
+    const capturedAt = new Date();
+    const rand = crypto.randomBytes(6).toString("hex");
+    const key = `proctoring/interviews/${meeting._id}/${capturedAt.getTime()}-${rand}.jpg`;
+
+    await uploadBufferToS3(req.file.buffer, key, req.file.mimetype);
+
+    await Meeting.updateOne(
+      { token },
+      {
+        $push: {
+          screenshots: { $each: [{ key, capturedAt }], $slice: -MAX_MEETING_SCREENSHOTS },
+        },
+      }
+    );
+
+    return res.status(201).json({ stored: true, capturedAt });
+  } catch (error) {
+    console.error("Error uploading meeting screenshot:", error);
+    return res.status(500).json({ message: "Failed to store screenshot" });
+  }
+};
+
+// @desc  Fetch presigned URLs for an interview's proctoring snapshots
+// @route GET /api/meetings/:meetingId/screenshots  (recruiter — owner only)
+export const getMeetingScreenshots = async (req, res) => {
+  try {
+    const recruiterId = req.id || req.user?._id;
+    if (!recruiterId) return res.status(401).json({ message: "Recruiter not authorized" });
+
+    const { meetingId } = req.params;
+    const meeting = await Meeting.findById(meetingId);
+    if (!meeting) return res.status(404).json({ message: "Meeting not found" });
+
+    if (String(meeting.recruiterId) !== String(recruiterId)) {
+      return res.status(403).json({ message: "Not authorized to view these screenshots" });
+    }
+
+    const shots = meeting.screenshots || [];
+    const screenshots = (
+      await Promise.all(
+        shots.map(async (s) => {
+          try {
+            const url = await getSignedImageUrl(s.key);
+            return url ? { url, capturedAt: s.capturedAt } : null;
+          } catch (e) {
+            console.error("Presign failed for", s.key, e?.message);
+            return null;
+          }
+        })
+      )
+    ).filter(Boolean);
+
+    return res.status(200).json({
+      consent: meeting.proctoringConsent || null,
+      count: screenshots.length,
+      screenshots,
+    });
+  } catch (error) {
+    console.error("Error fetching meeting screenshots:", error);
+    return res.status(500).json({ message: "Failed to fetch screenshots" });
+  }
+};

--- a/server/src/middleware/multer.js
+++ b/server/src/middleware/multer.js
@@ -1,4 +1,37 @@
-import multer from "multer";
+import multer, { MulterError } from "multer";
 
 const storage = multer.memoryStorage();
-export const singleUpload = multer({storage}).single("file");
+export const singleUpload = multer({ storage }).single("file");
+
+// Dedicated uploader for proctoring webcam frames. Kept separate from `singleUpload`
+// because these endpoints are PUBLIC (gated only by an unguessable id/token), so we
+// enforce a small size limit, a single file, and an image-only content type.
+const screenshotMulter = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 300 * 1024, files: 1 }, // ~300 KB is plenty for a 640px JPEG frame
+  fileFilter: (_req, file, cb) => {
+    if (file.mimetype === "image/jpeg" || file.mimetype === "image/png") {
+      cb(null, true);
+    } else {
+      cb(new MulterError("LIMIT_UNEXPECTED_FILE", "file"));
+    }
+  },
+}).single("file");
+
+// Wrap the multer middleware so its errors return a clean 4xx instead of bubbling to
+// the generic 500 handler. Runs before the controller, so this is the only place we
+// can translate MulterError codes.
+export const screenshotUpload = (req, res, next) => {
+  screenshotMulter(req, res, (err) => {
+    if (err instanceof MulterError) {
+      if (err.code === "LIMIT_FILE_SIZE") {
+        return res.status(413).json({ message: "Screenshot too large" });
+      }
+      return res.status(400).json({ message: "Invalid screenshot upload" });
+    }
+    if (err) {
+      return res.status(400).json({ message: "Upload failed" });
+    }
+    next();
+  });
+};

--- a/server/src/middleware/rateLimiters.js
+++ b/server/src/middleware/rateLimiters.js
@@ -11,6 +11,19 @@ export const openAILimiter = rateLimit({
     message: { message: "Too many requests, please slow down." },
 });
 
+// Throttle the public proctoring-screenshot upload endpoints. These are unauthenticated
+// (gated only by the unguessable assessmentId / meeting token), so cap per IP as
+// defense-in-depth alongside the size limit, session-state guard, and per-session cap.
+// A real session uploads ~3/min (one frame every 20s); the generous ceiling avoids
+// locking out multiple legitimate candidates sharing one NAT/corporate IP.
+export const screenshotLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { message: "Too many uploads, please slow down." },
+});
+
 // Cap admin-register attempts per IP. Defense-in-depth alongside the invite-secret guard.
 export const adminRegisterLimiter = rateLimit({
     windowMs: 15 * 60 * 1000,

--- a/server/src/models/meeting.model.js
+++ b/server/src/models/meeting.model.js
@@ -64,6 +64,18 @@ const meetingSchema = new mongoose.Schema(
     recordingUrl: {
       type: String,
     },
+    // Proctoring: periodic webcam snapshots captured during the interview.
+    // Only the S3 object key is stored; presigned URLs are minted on read.
+    screenshots: [
+      {
+        key: String, // e.g. proctoring/interviews/<meetingId>/<ts>-<rand>.jpg
+        capturedAt: Date,
+      },
+    ],
+    proctoringConsent: {
+      type: String,
+      enum: ["granted", "denied"],
+    },
     toolOutputs: {
       type: mongoose.Schema.Types.Mixed,
     },

--- a/server/src/models/resume.model.js
+++ b/server/src/models/resume.model.js
@@ -177,7 +177,17 @@ const ResumeSchema = new mongoose.Schema(
         feedback: String,
         complexityAnalysis: String,
         improvementSuggestions: String
-      }
+      },
+
+      // Proctoring: periodic webcam snapshots captured during the coding test.
+      // We store only the S3 object key; presigned URLs are minted on read.
+      proctoring: {
+        consent: { type: String, enum: ['granted', 'denied'] }
+      },
+      screenshots: [{
+        key: String,       // S3 object key, e.g. proctoring/assessments/<resumeId>/<assessmentId>/<ts>-<rand>.jpg
+        capturedAt: Date
+      }]
     },
 
     // Avaloq Banking Assessment
@@ -224,7 +234,16 @@ const ResumeSchema = new mongoose.Schema(
         feedback: String,
         complexityAnalysis: String,
         improvementSuggestions: String
-      }
+      },
+
+      // Proctoring: periodic webcam snapshots captured during the Avaloq test.
+      proctoring: {
+        consent: { type: String, enum: ['granted', 'denied'] }
+      },
+      screenshots: [{
+        key: String,
+        capturedAt: Date
+      }]
     },
 
     // Interview Management

--- a/server/src/routes/assessment.routes.js
+++ b/server/src/routes/assessment.routes.js
@@ -1,7 +1,9 @@
 import express from 'express';
-import { generateAssessment, generateAvaloqAssessment, getAssessment, submitAssessment, runCode } from '../controllers/assessment.controller.js';
+import { generateAssessment, generateAvaloqAssessment, getAssessment, submitAssessment, runCode, uploadAssessmentScreenshot, getAssessmentScreenshots } from '../controllers/assessment.controller.js';
 import { verifyRecruiterJWT } from '../middleware/recruiter.auth.middleware.js';
-import { openAILimiter } from '../middleware/rateLimiters.js';
+import { multiAuthMiddleware } from '../middleware/multi.auth.middleware.js';
+import { openAILimiter, screenshotLimiter } from '../middleware/rateLimiters.js';
+import { screenshotUpload } from '../middleware/multer.js';
 
 const router = express.Router();
 
@@ -12,9 +14,14 @@ router.get('/test/health', (req, res) => res.json({ status: "ok", message: "Asse
 router.post('/generate', verifyRecruiterJWT, openAILimiter, generateAssessment);
 router.post('/generate-avaloq', verifyRecruiterJWT, openAILimiter, generateAvaloqAssessment);
 
+// Recruiter/manager/admin: view proctoring snapshots for a session (presigned URLs).
+router.get('/:assessmentId/screenshots', multiAuthMiddleware, getAssessmentScreenshots);
+
 // Public candidate routes (No auth required, protected by assessmentId)
 router.get('/:assessmentId', getAssessment);
 router.post('/:assessmentId/submit', submitAssessment);
 router.post('/:assessmentId/run', runCode);
+// Public proctoring upload (gated by assessmentId; hardened by limiter + size/type + session guard).
+router.post('/:assessmentId/screenshot', screenshotLimiter, screenshotUpload, uploadAssessmentScreenshot);
 
 export default router;

--- a/server/src/routes/meeting.route.js
+++ b/server/src/routes/meeting.route.js
@@ -9,8 +9,12 @@ import {
   resendInvite,
   cancelMeeting,
   rescheduleMeeting,
+  uploadMeetingScreenshot,
+  getMeetingScreenshots,
 } from "../controllers/meeting.controller.js";
 import { verifyRecruiterJWT } from "../middleware/recruiter.auth.middleware.js";
+import { screenshotLimiter } from "../middleware/rateLimiters.js";
+import { screenshotUpload } from "../middleware/multer.js";
 import {
   validateCreateMeeting,
   validateStartMeeting,
@@ -21,9 +25,13 @@ const router = express.Router();
 
 router.post("/", verifyRecruiterJWT, validateCreateMeeting, createMeeting);
 router.get("/recruiter/meetings", verifyRecruiterJWT, getRecruiterMeetings);
+// Recruiter (owner only): presigned URLs for an interview's proctoring snapshots.
+router.get("/:meetingId/screenshots", verifyRecruiterJWT, getMeetingScreenshots);
 router.get("/:token", getMeetingByToken);
 router.post("/:token/start", validateStartMeeting, startMeeting);
 router.post("/:token/end", endMeeting);
+// Public proctoring upload (gated by the meeting token; hardened by limiter + size/type + active guard).
+router.post("/:token/screenshot", screenshotLimiter, screenshotUpload, uploadMeetingScreenshot);
 router.post("/:token/resend", verifyRecruiterJWT, resendInvite);
 router.post("/:token/cancel", verifyRecruiterJWT, cancelMeeting);
 router.post(
@@ -35,4 +43,3 @@ router.post(
 router.post("/webhook/vapi", handleVapiWebhook);
 
 export default router;
-

--- a/server/src/utils/s3.js
+++ b/server/src/utils/s3.js
@@ -1,0 +1,54 @@
+import { S3Client, PutObjectCommand, GetObjectCommand } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import dotenv from "dotenv";
+dotenv.config();
+
+// Read once at module load. See S3_PROCTORING_SETUP.md for how to obtain these.
+const region = process.env.AWS_REGION;
+const bucket = process.env.AWS_S3_BUCKET;
+const accessKeyId = process.env.AWS_ACCESS_KEY_ID;
+const secretAccessKey = process.env.AWS_SECRET_ACCESS_KEY;
+
+// True only when every value needed to talk to S3 is present. Controllers check this
+// so a deploy without AWS credentials degrades gracefully instead of throwing.
+export const isS3Configured = () =>
+  Boolean(region && bucket && accessKeyId && secretAccessKey);
+
+// Lazily construct the client so importing this module never throws when creds are absent.
+let _client = null;
+const getClient = () => {
+  if (!_client) {
+    _client = new S3Client({
+      region,
+      credentials: { accessKeyId, secretAccessKey },
+    });
+  }
+  return _client;
+};
+
+// Upload a raw Buffer (from multer memoryStorage) to a private object. Returns the key.
+export const uploadBufferToS3 = async (buffer, key, contentType) => {
+  if (!isS3Configured()) throw new Error("S3 is not configured");
+  await getClient().send(
+    new PutObjectCommand({
+      Bucket: bucket,
+      Key: key,
+      Body: buffer,
+      ContentType: contentType || "image/jpeg",
+    })
+  );
+  return key;
+};
+
+// Mint a short-lived presigned GET URL for a private object. Returns null (never throws)
+// when S3 is unconfigured or the key is empty, so a single failure can't break a listing.
+export const getSignedImageUrl = async (key, expiresIn = 43200) => {
+  if (!isS3Configured() || !key) return null;
+  return getSignedUrl(
+    getClient(),
+    new GetObjectCommand({ Bucket: bucket, Key: key }),
+    { expiresIn }
+  );
+};
+
+export default { isS3Configured, uploadBufferToS3, getSignedImageUrl };


### PR DESCRIPTION
Capture the candidate's webcam periodically during the coding test (/assessment/:id) and the AI video interview (/meeting/:token), store the frames in a private S3 bucket, and let the recruiter view them to confirm the same real person took both.

Server
- New utils/s3.js: lazy S3 client, uploadBufferToS3, getSignedImageUrl (presigned GET), isS3Configured — degrades gracefully when AWS env is unset.
- Models: screenshots [{key, capturedAt}] + consent on resume.oa/avaloqOa and Meeting.
- Public, id/token-gated upload endpoints hardened with an image-only, 300KB multer instance, an IP rate limiter, session-state guards, and an atomic $push/$slice cap.
- Recruiter (owner-scoped) read endpoints returning presigned URLs.

Client
- Shared utils/proctoring.js (capture frame -> JPEG -> multipart upload, best-effort).
- Camera-gated coding test and interview: block start until camera granted, pause the assessment timer during the prompt, capture every 30s, stop on all teardown paths.
- ProctoringGallery in the recruiter assessment + interview result views (self-hides when empty, flags camera-denied).

Docs
- S3_PROCTORING_SETUP.md: step-by-step AWS bucket/IAM setup + least-privilege policy.